### PR TITLE
Do not create permissions for default behavior

### DIFF
--- a/src/FieldPermissionsService.php
+++ b/src/FieldPermissionsService.php
@@ -96,11 +96,16 @@ class FieldPermissionsService implements FieldPermissionsServiceInterface {
     $instances = \Drupal::entityTypeManager()->getStorage('field_storage_config')->loadMultiple();
     foreach ($instances as $key => $instance) {
       $field_name = $instance->getName();
-      $permission_list = FieldPermissionsService::getList($field_name);
-      $perms_name = array_keys($permission_list);
-      foreach ($perms_name as $perm_name) {
-        $name = str_replace(' ', '_', $perm_name) . '_' . $field_name;
-        $permissions[$name] = $permission_list[$perm_name];
+
+      // Check if permissionType is not default, before creating permissions.
+      $type = FieldPermissionsService::fieldGetPermissionType($instance);
+      if ($type <> FIELD_PERMISSIONS_PUBLIC) {
+        $permission_list = FieldPermissionsService::getList($field_name);
+        $perms_name = array_keys($permission_list);
+        foreach ($perms_name as $perm_name) {
+          $name = str_replace(' ', '_', $perm_name) . '_' . $field_name;
+          $permissions[$name] = $permission_list[$perm_name];
+        }
       }
     }
     return $permissions;

--- a/src/FieldPermissionsService.php
+++ b/src/FieldPermissionsService.php
@@ -91,16 +91,21 @@ class FieldPermissionsService implements FieldPermissionsServiceInterface {
   /**
    * {@inheritdoc}
    */
-  public function permissions() {
+  public static function permissions() {
     $permissions = [];
     $instances = \Drupal::entityTypeManager()->getStorage('field_storage_config')->loadMultiple();
     foreach ($instances as $key => $instance) {
       $field_name = $instance->getName();
-      $permission_list = FieldPermissionsService::getList($field_name);
-      $perms_name = array_keys($permission_list);
-      foreach ($perms_name as $perm_name) {
-        $name = str_replace(' ', '_', $perm_name) . '_' . $field_name;
-        $permissions[$name] = $permission_list[$perm_name];
+
+      // Check if permissionType is not default, before creating permissions.
+      $type = FieldPermissionsService::fieldGetPermissionType($instance);
+      if ($type <> FIELD_PERMISSIONS_PUBLIC) {
+        $permission_list = FieldPermissionsService::getList($field_name);
+        $perms_name = array_keys($permission_list);
+        foreach ($perms_name as $perm_name) {
+          $name = str_replace(' ', '_', $perm_name) . '_' . $field_name;
+          $permissions[$name] = $permission_list[$perm_name];
+        }
       }
     }
     return $permissions;


### PR DESCRIPTION
This patch only creates new permissions when field_permissions are actually used. Advantage of this is that the permissions table does not get overpopulated on install.
